### PR TITLE
rpcs3/pcsx2: use more standardized and capitalized package option names

### DIFF
--- a/pcsx2-dev/pcsx2-dev.nuspec
+++ b/pcsx2-dev/pcsx2-dev.nuspec
@@ -19,8 +19,8 @@ Recompilers and a Virtual Machine which manages hardware states and PS2 system m
 #### Package Parameters
 The following package parameters can be set:
 
- * `/Desktop` - Add a desktop shortcut
- * `/Nostart` - Do not add a start menu shortcut
+ * `/DesktopShortcut` - Add a desktop shortcut
+ * `/NoStart` - Do not add a start menu shortcut
  * `/Path:C:\path\to\install` - Custom path to put files in
  
 To pass parameters, use `--params "''"` (e.g. `choco install packageID [other options] --params="'/ITEM:value /ITEM2:value2 /FLAG_BOOLEAN'"`).

--- a/pcsx2-dev/tools/chocolateyinstall.ps1
+++ b/pcsx2-dev/tools/chocolateyinstall.ps1
@@ -48,12 +48,12 @@ Write-Host -ForegroundColor white "Copying files to $destination"
 $fileList = Get-ChildItem -Path $tempPath | Copy-Item -Destination $destination -Recurse -Force -PassThru
 $fileList | select -ExpandProperty FullName | Out-File -Force -FilePath (Join-Path $toolsDir 'install-files.txt')
 
-if (!$pp['nostart']) {
+if (!$pp['NoStart']) {
     Write-Host -ForegroundColor white 'Adding ' $startPath
 	Install-ChocolateyShortcut -ShortcutFilePath "$startPath" -TargetPath "$exePath" -WorkingDirectory "$destination"
 }
 
-if ($pp['Desktop']) {
+if ($pp['Desktop'] -or $pp['DesktopShortcut']) {
     Write-Host -ForegroundColor white 'Adding ' $desktopPath
 	Install-ChocolateyShortcut -ShortcutFilePath "$desktopPath" -TargetPath "$exePath" -WorkingDirectory "$destination"
 }

--- a/pcsx2.install/pcsx2.install.nuspec
+++ b/pcsx2.install/pcsx2.install.nuspec
@@ -22,7 +22,7 @@ This package version uses an AutoHotKey to run the installer, as the silent swit
 #### Package Parameters
 The following package parameters can be set:
 
- * `/Desktop` - Add a desktop shortcut
+ * `/DesktopShortcut` - Add a desktop shortcut
  
 To pass parameters, use `--params "''"` (e.g. `choco install packageID [other options] --params="'/ITEM:value /ITEM2:value2 /FLAG_BOOLEAN'"`).
 To have choco remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.	</description>

--- a/pcsx2.install/tools/chocolateyinstall.ps1
+++ b/pcsx2.install/tools/chocolateyinstall.ps1
@@ -9,7 +9,7 @@ AutoHotkey $ahkScript "$installer"
 
 Remove-Item -Force -ea 0 -Path $toolsDir\*.exe
 
-if (!$pp['DESKTOP']) {
+if (!$pp['DESKTOP'] -or $pp['DesktopShortcut']) {
 	$shortcut = Get-Childitem -Path ([System.IO.Path]::Combine(([System.Environment]::GetFolderPath("Desktop")), $shortcutName)) -Filter "PCSX2 *.lnk"
     Remove-Item -ea 0 -Path $shortcut.fullname
 }

--- a/pcsx2.portable/pcsx2.portable.nuspec
+++ b/pcsx2.portable/pcsx2.portable.nuspec
@@ -19,8 +19,8 @@ Recompilers and a Virtual Machine which manages hardware states and PS2 system m
 #### Package Parameters
 The following package parameters can be set:
 
- * `/Desktop` - Add a desktop shortcut
- * `/Nostart` - Do not add a start menu shortcut
+ * `/DesktopShortcut` - Add a desktop shortcut
+ * `/NoStart` - Do not add a start menu shortcut
  * `/Path:C:\path\to\install` - Custom path to put files in
  
 To pass parameters, use `--params "''"` (e.g. `choco install packageID [other options] --params="'/ITEM:value /ITEM2:value2 /FLAG_BOOLEAN'"`).

--- a/pcsx2.portable/tools/chocolateyinstall.ps1
+++ b/pcsx2.portable/tools/chocolateyinstall.ps1
@@ -41,12 +41,12 @@ $fileList | select -ExpandProperty FullName | Out-File -Force -FilePath (Join-Pa
 
 $exePath = Join-Path "$destination" "pcsx2.exe"
 
-if (!$pp['nostart']) {
+if (!$pp['NoStart']) {
     Write-Host -ForegroundColor white 'Adding ' $startPath
 	Install-ChocolateyShortcut -ShortcutFilePath "$startPath" -TargetPath "$exePath" -WorkingDirectory "$destination"
 }
 
-if ($pp['Desktop']) {
+if ($pp['Desktop'] -or $pp['DesktopShortcut']) {
     Write-Host -ForegroundColor white 'Adding ' $desktopPath
 	Install-ChocolateyShortcut -ShortcutFilePath "$desktopPath" -TargetPath "$exePath" -WorkingDirectory "$destination"
 }

--- a/rpcs3/tools/chocolateyinstall.ps1
+++ b/rpcs3/tools/chocolateyinstall.ps1
@@ -25,13 +25,13 @@ Remove-Item -Force -Path $toolsDir\*.7z
 
 Install-BinFile -Name 'RPCS3' -Path $exepath -UseStart
 
-if ($pp['desktopicon']) {
+if ($pp['desktopicon'] -or $pp['DesktopShortcut']) {
 	$desktopicon = (Join-Path ([System.Environment]::GetFolderPath("CommonDesktop")) $shortcutName)
 	Write-Host -ForegroundColor white 'Adding ' $desktopicon
 	Install-ChocolateyShortcut -ShortcutFilePath $desktopicon -TargetPath $exepath  -RunAsAdmin
 }
 
-if (!$pp['nostart']) {
+if (!$pp['NoStart']) {
 	$starticon = (Join-Path ([System.Environment]::GetFolderPath("CommonPrograms")) $shortcutName)
 	Write-Host -ForegroundColor white 'Adding ' $starticon
 	Install-ChocolateyShortcut -ShortcutFilePath $starticon -TargetPath $exepath  -RunAsAdmin


### PR DESCRIPTION
Most package i've seen using "DesktopShortcut" option name and most of them are capitalized. With this change people like me who install pcsx2 and rpcs3 with desktop icons can use `--params "/DesktopShortcut"` instead of `--params "/desktopicon /Desktop"`, which is shorter.