### PR TITLE
rpcs3: add /NoAdmin param to make launching as admin optional

### DIFF
--- a/rpcs3/rpcs3.nuspec
+++ b/rpcs3/rpcs3.nuspec
@@ -12,8 +12,17 @@
     <iconUrl>https://rpcs3.net/img/icons/menu/logo.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>RPCS3 is a multi-platform open-source Sony PlayStation 3 emulator and debugger written in C++ for Windows, Linux and BSD. It was founded by programmers DH and Hykem. Initially hosted on Google Code, the project was eventually migrated to GitHub later on in its development. RPCS3's first successful boots were primarily composed of small homebrew projects and hardware tests. The emulator was later publicly released in June of 2012 and gained substantial attention from both the open-source community and PlayStation enthusiasts alike. Today, RPCS3 is primarily developed by its two lead developers; Nekotekina, kd-11 and backed by flourishing team of GitHub contributors.
-    
-    **Please Note**: This is an automatically updated package. If you find it is
+
+### Package Specific
+#### Package Parameters
+The following package parameters can be set:
+
+    * `/NoAdmin` - Do not set the desktop and start menu shortcuts to launch as administrator.
+
+To pass parameters, use `--params "''"` (e.g. `choco install packageID [other options] --params="'/ITEM:value /ITEM2:value2 /FLAG_BOOLEAN'"`).
+To have choco remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
+
+**Please Note**: This is an automatically updated package. If you find it is
 out of date by more than a day or two, please contact the maintainer(s) and
 let them know the package is no longer updating correctly.</description>
     <summary>An Open-source Sony PlayStation 3 Emulator for Windows and Linux</summary>

--- a/rpcs3/tools/chocolateyinstall.ps1
+++ b/rpcs3/tools/chocolateyinstall.ps1
@@ -5,6 +5,7 @@ $shortcutName          = 'RPCS3.lnk'
 $extractDir            = $(Get-ToolsLocation)
 $rpcs3Dir              = (Join-Path $extractDir 'RPCS3')
 $exepath               = (Join-Path $rpcs3Dir 'rpcs3.exe')
+$admin                 = "-RunAsAdmin"
 
 $packageArgs = @{
     PackageName  = $env:ChocolateyPackageName
@@ -25,14 +26,18 @@ Remove-Item -Force -Path $toolsDir\*.7z
 
 Install-BinFile -Name 'RPCS3' -Path $exepath -UseStart
 
+if ($pp['NoAdmin']) {
+	Remove-Variable -name "admin"
+}
+
 if ($pp['desktopicon'] -or $pp['DesktopShortcut']) {
 	$desktopicon = (Join-Path ([System.Environment]::GetFolderPath("CommonDesktop")) $shortcutName)
 	Write-Host -ForegroundColor white 'Adding ' $desktopicon
-	Install-ChocolateyShortcut -ShortcutFilePath $desktopicon -TargetPath $exepath  -RunAsAdmin
+	Install-ChocolateyShortcut -ShortcutFilePath $desktopicon -TargetPath $exepath $admin
 }
 
 if (!$pp['NoStart']) {
 	$starticon = (Join-Path ([System.Environment]::GetFolderPath("CommonPrograms")) $shortcutName)
 	Write-Host -ForegroundColor white 'Adding ' $starticon
-	Install-ChocolateyShortcut -ShortcutFilePath $starticon -TargetPath $exepath  -RunAsAdmin
+	Install-ChocolateyShortcut -ShortcutFilePath $starticon -TargetPath $exepath $admin
 }


### PR DESCRIPTION
I've tested this and it works, rpcs3 is launched without UAC prompt.

@TheCakeIsNaOH