### PR TITLE
yt-dlp: Remove dependency on vcredist2010

### DIFF
--- a/yt-dlp/yt-dlp.nuspec
+++ b/yt-dlp/yt-dlp.nuspec
@@ -29,9 +29,6 @@ out of date by more than a day or two, please contact the maintainer(s) and
 let them know the package is no longer updating correctly.
 </description>
     <releaseNotes>https://github.com/yt-dlp/yt-dlp/releases/</releaseNotes>
-    <dependencies>
-      <dependency id="vcredist2010" version="10.0.40219.1" />
-    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
This pull request aims to remove the dependency on vcredist2010 listed in yt-dlp's Chocolatey package.

Given that [the Microsoft Visual C++ 2010 Redistributable hasn't been supported since 2020](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#visual-studio-2010-vc-100-sp1-no-longer-supported), its installation alongside yt-dlp caught my eye, especially when my winget installation of the same program didn't have such a dependency.

According to [an issue previously opened in yt-dlp's GitHub repository](https://github.com/yt-dlp/yt-dlp/issues/1163), the Microsoft Visual C++ Redistributable that the program depends on has long been embedded into the yt-dlp binary itself. To be sure, I set up a sandboxed environment with only Chocolatey and a base installation of Windows 10. After manually uninstalling the vcredist2010 package, the version of yt-dlp downloaded from this repository still executes successfully on my system.

I hope you'll consider incorporating this patch, as it will increase the security of your users by no longer pushing them to install an unsupported dependency. Thanks in advance, and please let me know if there's anything else that would help this change go through!