### PR TITLE
d2: update repository URLs

### DIFF
--- a/d2/d2.nuspec
+++ b/d2/d2.nuspec
@@ -8,7 +8,7 @@
     <authors>Terrastruct</authors>
     <owners>TheCakeIsNaOH</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <licenseUrl>https://raw.githubusercontent.com/terrastruct/d2/master/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://raw.githubusercontent.com/d2lang/d2/master/LICENSE.txt</licenseUrl>
     <projectUrl>https://d2lang.com/</projectUrl>
     <iconUrl>https://cdn.statically.io/gh/TheCakeIsNaOH/chocolatey-packages/41ec4572cb7df4909759dc9bfbb8c771ef32f395/Icons/d2.png</iconUrl>
     <summary>A modern diagram scripting language that turns text to diagrams.</summary>
@@ -25,10 +25,10 @@
     <releaseNotes>https://github.com/PowerShell/Win32-d2/releases</releaseNotes>
     <copyright>Copyright 2024 Terrastruct Inc.</copyright>
     <tags>d2 d2lang diagrams admin</tags>
-    <projectSourceUrl>https://github.com/terrastruct/d2</projectSourceUrl>
+    <projectSourceUrl>https://github.com/d2lang/d2</projectSourceUrl>
     <packageSourceUrl>https://github.com/TheCakeIsNaOH/chocolatey-packages/tree/master/d2</packageSourceUrl>
     <docsUrl>https://d2lang.com/tour/intro/</docsUrl>
-    <bugTrackerUrl>https://github.com/terrastruct/d2/issues</bugTrackerUrl>
+    <bugTrackerUrl>https://github.com/d2lang/d2/issues</bugTrackerUrl>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/d2/legal/VERIFICATION.txt
+++ b/d2/legal/VERIFICATION.txt
@@ -7,7 +7,7 @@ Package can be verified like this:
 
 1. Go to
 
-   x64: https://github.com/terrastruct/d2/releases/download/v0.7.1/d2-v0.7.1-windows-amd64.msi
+   x64: https://github.com/d2lang/d2/releases/download/v0.7.1/d2-v0.7.1-windows-amd64.msi
    
    to download the zip.
 


### PR DESCRIPTION
The D2 GitHub repositories have moved from the Terrastruct organization to `d2lang`.

This updates the active Chocolatey metadata and verification source URLs while preserving the package version, MSI, checksum, author attribution, and release mechanism.

Validation:
- `xmllint --noout d2/d2.nuspec`
- all updated URLs return successfully
- the MSI at the new URL hashes to `45c75848c0201ec68b3a3a88179a3294c7b12204e39b42bd62c76c6c6ea1613d`, matching `VERIFICATION.txt`
- `git diff --check`

Codex (OpenAI) assisted with the URL-only change and PR preparation; the diff and validation results were reviewed before requesting review.